### PR TITLE
fix: 디테일뷰 mbti 찌부 수정, 알림탭 오류 수정, 새친구 수정, 필터 기본나이 수정, test아이디 안나오게 수정

### DIFF
--- a/Pico/Home/CompatibilityView.swift
+++ b/Pico/Home/CompatibilityView.swift
@@ -138,23 +138,11 @@ final class CompatibilityView: UIView {
             make.edges.equalToSuperview()
         }
         
-        compatibilityLabel.snp.makeConstraints { make in
-            make.centerX.equalToSuperview()
-            make.centerY.equalToSuperview().offset(-20)
-        }
-        
-        starStackView.snp.makeConstraints { make in
-            make.centerX.equalToSuperview()
-            make.top.equalTo(compatibilityLabel.snp.bottom).offset(20)
-            make.width.equalTo(200)
-            make.height.equalTo(30)
-        }
-        
         myProfileView.snp.makeConstraints { make in
             make.top.equalToSuperview().offset(50)
             make.leading.equalToSuperview().offset(50)
             make.trailing.equalTo(safeAreaLayoutGuide.snp.centerX).offset(-10)
-            make.bottom.equalTo(safeAreaLayoutGuide.snp.centerY).offset(-60)
+            make.bottom.equalTo(myProfileView.snp.top).offset(180)
         }
         
         myImage.snp.makeConstraints { make in
@@ -175,7 +163,7 @@ final class CompatibilityView: UIView {
             make.top.equalToSuperview().offset(50)
             make.leading.equalTo(safeAreaLayoutGuide.snp.centerX).offset(10)
             make.trailing.equalToSuperview().offset(-50)
-            make.bottom.equalTo(safeAreaLayoutGuide.snp.centerY).offset(-60)
+            make.bottom.equalTo(userProfileView.snp.top).offset(180)
         }
         
         userImage.snp.makeConstraints { make in
@@ -190,6 +178,18 @@ final class CompatibilityView: UIView {
             make.leading.equalTo(userProfileView).offset(10)
             make.trailing.equalTo(userProfileView).offset(-10)
             make.bottom.equalTo(userProfileView).offset(-10)
+        }
+        
+        compatibilityLabel.snp.makeConstraints { make in
+            make.top.equalTo(myProfileView.snp.bottom).offset(40)
+            make.centerX.equalToSuperview()
+        }
+        
+        starStackView.snp.makeConstraints { make in
+            make.top.equalTo(compatibilityLabel.snp.bottom).offset(15)
+            make.centerX.equalToSuperview()
+            make.width.equalTo(200)
+            make.height.equalTo(30)
         }
     }
 }

--- a/Pico/Home/HomeEmptyView.swift
+++ b/Pico/Home/HomeEmptyView.swift
@@ -29,7 +29,8 @@ final class HomeEmptyView: UIView {
     private let finishLabel: UILabel = {
         let label = UILabel()
         let text = """
-                    더 이상 추천이 없어요.
+                    이번 추천이 완료되었어요.
+                    새 친구를 불러오거나
                     선호 설정을 조절해 보세요.
                     """
         let attributedText = NSMutableAttributedString(string: text)
@@ -47,7 +48,8 @@ final class HomeEmptyView: UIView {
     // 상위뷰에서 에드타겟
     let reLoadButton: UIButton = {
         let button = UIButton()
-        button.setTitle("새 친구 찾아보기", for: .normal)
+        button.setTitle("새 추천 불러오기", for: .normal)
+        button.titleLabel?.textAlignment = .center
         button.setTitleColor(.white, for: .normal)
         button.titleLabel?.font = .picoButtonFont
         button.backgroundColor = .picoBlue
@@ -59,8 +61,20 @@ final class HomeEmptyView: UIView {
     let backUser: UIButton = {
         let button = UIButton()
         button.setTitle("이전 친구보기", for: .normal)
+        button.titleLabel?.textAlignment = .center
         button.setTitleColor(.picoBlue, for: .normal)
         button.titleLabel?.font = .picoButtonFont
+        button.layer.cornerRadius = 15
+        return button
+    }()
+    
+    let goToFilterView: UIButton = {
+        let button = UIButton()
+        button.setTitle("선호 설정 조절", for: .normal)
+        button.titleLabel?.textAlignment = .center
+        button.setTitleColor(.white, for: .normal)
+        button.titleLabel?.font = .picoButtonFont
+        button.backgroundColor = .picoBlue
         button.layer.cornerRadius = 15
         return button
     }()
@@ -78,7 +92,7 @@ final class HomeEmptyView: UIView {
     }
     
     private func addViews() {
-        [animationView, chuImage, reLoadButton, finishLabel, backUser].forEach { item in
+        [animationView, chuImage, reLoadButton, finishLabel, goToFilterView, backUser].forEach { item in
             addSubview(item)
         }
     }
@@ -102,17 +116,24 @@ final class HomeEmptyView: UIView {
         }
         
         reLoadButton.snp.makeConstraints { make in
-            make.top.equalTo(finishLabel.snp.bottom).offset(20)
+            make.top.equalTo(finishLabel.snp.bottom).offset(10)
             make.centerX.equalToSuperview()
             make.width.equalTo(140)
-            make.height.equalTo(35)
+            make.height.equalTo(30)
         }
         
-        backUser.snp.makeConstraints { make in
+        goToFilterView.snp.makeConstraints { make in
             make.top.equalTo(reLoadButton.snp.bottom).offset(10)
             make.centerX.equalToSuperview()
             make.width.equalTo(140)
-            make.height.equalTo(35)
+            make.height.equalTo(30)
+        }
+        
+        backUser.snp.makeConstraints { make in
+            make.top.equalTo(goToFilterView.snp.bottom).offset(10)
+            make.centerX.equalToSuperview()
+            make.width.equalTo(140)
+            make.height.equalTo(30)
         }
     }
 }

--- a/Pico/Home/HomeUserCardViewController.swift
+++ b/Pico/Home/HomeUserCardViewController.swift
@@ -337,14 +337,15 @@ final class HomeUserCardViewController: UIViewController {
                     HomeUserCardViewModel.cardCounting = -1
                     homeViewController?.addUserCards()
                 }
-
-                NotificationService.shared.sendNotification(userId: user.id, sendUserName: currentUser.nickName, notiType: .like)
-                guard let myMbti = MBTIType(rawValue: currentUser.mbti) else { return }
-                let noti = Noti(receiveId: user.id, sendId: currentUser.userId, name: currentUser.nickName, birth: currentUser.birth, imageUrl: currentUser.imageURL, notiType: .like, mbti: myMbti, createDate: Date().timeIntervalSince1970)
-                FirestoreService.shared.saveDocument(collectionId: .notifications, data: noti)
+                if currentUser.userId.prefix(4) != "test" {
+                    viewModel.saveLikeData(receiveUserInfo: user, likeType: .like)
+                    NotificationService.shared.sendNotification(userId: user.id, sendUserName: currentUser.nickName, notiType: .like)
+                    guard let myMbti = MBTIType(rawValue: currentUser.mbti) else { return }
+                    let noti = Noti(receiveId: user.id, sendId: currentUser.userId, name: currentUser.nickName, birth: currentUser.birth, imageUrl: currentUser.imageURL, notiType: .like, mbti: myMbti, createDate: Date().timeIntervalSince1970)
+                    FirestoreService.shared.saveDocument(collectionId: .notifications, data: noti)
+                }
 
                 UIView.animate(withDuration: 0.5) { [self] in
-                    viewModel.saveLikeData(receiveUserInfo: user, likeType: .like)
                     homeViewController?.removedView.append(view)
                     view.center.x += 1000
                     homeViewController?.likeLabel.alpha = 0
@@ -355,7 +356,9 @@ final class HomeUserCardViewController: UIViewController {
                     HomeUserCardViewModel.cardCounting = -1
                     homeViewController?.addUserCards()
                 }
-                self.viewModel.saveLikeData(receiveUserInfo: user, likeType: .dislike)
+                if currentUser.userId.prefix(4) != "test" {
+                    self.viewModel.saveLikeData(receiveUserInfo: user, likeType: .dislike)
+                }
                 UIView.animate(withDuration: 0.5) { [self] in
                     homeViewController?.removedView.append(view)
                     view.center.x -= 1000
@@ -374,20 +377,26 @@ final class HomeUserCardViewController: UIViewController {
         }
     }
     @objc func tappedLikeButton() {
+        var matching = false
         self.homeViewController?.removedView.append(self.view)
         self.homeViewController?.likeLabel.alpha = 1
-        self.viewModel.saveLikeData(receiveUserInfo: user, likeType: .like)
-        
         HomeUserCardViewModel.cardCounting += 1
         if HomeUserCardViewModel.cardCounting == 3 {
             HomeUserCardViewModel.cardCounting = -1
             homeViewController?.addUserCards()
         }
-
-        NotificationService.shared.sendNotification(userId: user.id, sendUserName: currentUser.nickName, notiType: .like)
-        guard let myMbti = MBTIType(rawValue: currentUser.mbti) else { return }
-        let noti = Noti(receiveId: user.id, sendId: currentUser.userId, name: currentUser.nickName, birth: currentUser.birth, imageUrl: currentUser.imageURL, notiType: .like, mbti: myMbti, createDate: Date().timeIntervalSince1970)
-        FirestoreService.shared.saveDocument(collectionId: .notifications, data: noti)
+        if currentUser.userId.prefix(4) != "test" {
+            // 누르면 서버에서 나를 Like 했는지 조회하고 맞으면
+            if matching {
+                
+            } else {
+                self.viewModel.saveLikeData(receiveUserInfo: user, likeType: .like)
+                NotificationService.shared.sendNotification(userId: user.id, sendUserName: currentUser.nickName, notiType: .like)
+                guard let myMbti = MBTIType(rawValue: currentUser.mbti) else { return }
+                let noti = Noti(receiveId: user.id, sendId: currentUser.userId, name: currentUser.nickName, birth: currentUser.birth, imageUrl: currentUser.imageURL, notiType: .like, mbti: myMbti, createDate: Date().timeIntervalSince1970)
+                FirestoreService.shared.saveDocument(collectionId: .notifications, data: noti)
+            }
+        }
 
         UIView.animate(withDuration: 0.5) {
             self.view.center.x += 1000
@@ -399,12 +408,16 @@ final class HomeUserCardViewController: UIViewController {
     @objc func tappedDisLikeButton() {
         self.homeViewController?.removedView.append(self.view)
         self.homeViewController?.passLabel.alpha = 1
-        self.viewModel.saveLikeData(receiveUserInfo: user, likeType: .dislike)
         HomeUserCardViewModel.cardCounting += 1
         if HomeUserCardViewModel.cardCounting == 3 {
             HomeUserCardViewModel.cardCounting = -1
             homeViewController?.addUserCards()
         }
+        
+        if currentUser.userId.prefix(4) != "test" {
+            self.viewModel.saveLikeData(receiveUserInfo: user, likeType: .dislike)
+        }
+        
         UIView.animate(withDuration: 0.5) {
             self.view.center.x -= 1000
         } completion: { _ in
@@ -425,7 +438,9 @@ final class HomeUserCardViewController: UIViewController {
                     let remainingChu = UserDefaultsManager.shared.getChuCount()
                     if remainingChu >= 10 {
                         viewModel.purchaseChu(currentChu: remainingChu, purchaseChu: 10)
-                        self.viewModel.deleteLikeData()
+                        if currentUser.userId.prefix(4) != "test" {
+                            self.viewModel.deleteLikeData()
+                        }
                         UIView.animate(withDuration: 0.3) {
                             lastView.center = self.view.center
                             lastView.transform = CGAffineTransform(rotationAngle: 0)

--- a/Pico/Home/HomeViewController.swift
+++ b/Pico/Home/HomeViewController.swift
@@ -59,7 +59,7 @@ final class HomeViewController: BaseViewController {
         bind()
         loadCards()
     }
-
+    
     private func bind() {
         viewModel.users
             .bind(to: users)
@@ -108,7 +108,7 @@ final class HomeViewController: BaseViewController {
                 return users.filter { user in
                     var maxAge: Int = HomeViewModel.filterAgeMax
                     var maxDistance: Int = HomeViewModel.filterDistance
-                    if HomeViewModel.filterAgeMax == 61 {
+                    if HomeViewModel.filterAgeMax >= 61 {
                         maxAge = 100
                     }
                     if HomeViewModel.filterDistance == 501 {
@@ -188,21 +188,33 @@ final class HomeViewController: BaseViewController {
     
     private func configButtons() {
         emptyView.reLoadButton.addTarget(self, action: #selector(reloadView), for: .touchUpInside)
+        emptyView.goToFilterView.addTarget(self, action: #selector(tappedFilterButton), for: .touchUpInside)
         emptyView.backUser.addTarget(self, action: #selector(tappedPickBackButton), for: .touchUpInside)
     }
     
     private func configNavigationBarItem() {
-        let filterImage = UIImage(systemName: "slider.horizontal.3")
-        let filterButton = UIBarButtonItem(image: filterImage, style: .plain, target: self, action: #selector(tappedFilterButton))
+        let filterButton = UIButton(type: .custom)
+        let filterImage = UIImage(systemName: "slider.horizontal.3")?.withConfiguration(UIImage.SymbolConfiguration(pointSize: 21))
+        filterButton.setImage(filterImage, for: .normal)
+        filterButton.frame.size = CGSize(width: 30, height: 30)
         filterButton.tintColor = .darkGray
+        filterButton.addTarget(self, action: #selector(tappedFilterButton), for: .touchUpInside)
         filterButton.accessibilityLabel = "필터"
-        let notificationImage = UIImage(systemName: "bell.fill")
-        let notificationButton = UIBarButtonItem(image: notificationImage, style: .plain, target: self, action: #selector(tappedNotificationButton))
+        
+        let notificationButton = UIButton(type: .custom)
+        let notificationImage = UIImage(systemName: "bell.fill")?.withConfiguration(UIImage.SymbolConfiguration(pointSize: 21))
+        notificationButton.setImage(notificationImage, for: .normal)
+        notificationButton.frame.size = CGSize(width: 30, height: 30)
         notificationButton.tintColor = .darkGray
+        notificationButton.addTarget(self, action: #selector(tappedNotificationButton), for: .touchUpInside)
         notificationButton.accessibilityLabel = "알림"
-        navigationItem.rightBarButtonItems = [filterButton, notificationButton]
+        
+        let filterBarButtonItem = UIBarButtonItem(customView: filterButton)
+        let notificationBarButtonItem = UIBarButtonItem(customView: notificationButton)
+        
+        navigationItem.rightBarButtonItems = [filterBarButtonItem, notificationBarButtonItem]
     }
-    
+
     @objc func tappedPickBackButton() {
         if let lastView = removedView.last {
             showCustomAlert(
@@ -231,7 +243,7 @@ final class HomeViewController: BaseViewController {
                 }
             )
         } else {
-            showCustomAlert(alertType: .onlyConfirm, titleText: "이전 친구가 없습니다.", messageText: "", confirmButtonText: "확인")
+            showCustomAlert(alertType: .onlyConfirm, titleText: "이전 친구를 찾을 수 없습니다.", messageText: "", confirmButtonText: "확인")
         }
     }
     
@@ -245,12 +257,14 @@ final class HomeViewController: BaseViewController {
     @objc func tappedFilterButton() {
         let viewController = HomeFilterViewController()
         viewController.homeViewController = self
+        viewController.hidesBottomBarWhenPushed = true
         addChild(viewController)
         navigationController?.pushViewController(viewController, animated: true)
     }
     
     @objc func tappedNotificationButton() {
         let viewController = NotificationViewController()
+        viewController.hidesBottomBarWhenPushed = true
         navigationController?.pushViewController(viewController, animated: true)
     }
 }

--- a/Pico/Home/HomeViewController.swift
+++ b/Pico/Home/HomeViewController.swift
@@ -243,7 +243,7 @@ final class HomeViewController: BaseViewController {
                 }
             )
         } else {
-            showCustomAlert(alertType: .onlyConfirm, titleText: "이전 친구를 찾을 수 없습니다.", messageText: "", confirmButtonText: "확인")
+            showCustomAlert(alertType: .onlyConfirm, titleText: "이전 친구를 찾을 수 없습니다.", messageText: "매칭된 상대는 되돌릴 수 없습니다.", confirmButtonText: "확인")
         }
     }
     

--- a/Pico/Home/ViewModel/HomeUserCardViewModel.swift
+++ b/Pico/Home/ViewModel/HomeUserCardViewModel.swift
@@ -15,6 +15,7 @@ final class HomeUserCardViewModel {
     private let sendedlikesUpdateFiled = "sendedlikes"
     private let recivedlikesUpdateFiled = "recivedlikes"
     private let docRef = Firestore.firestore().collection(Collections.likes.name)
+    private var partnerSendedLikeData: Like.LikeInfo = Like.LikeInfo(likedUserId: "", likeType: .dislike, birth: "", nickName: "", mbti: .enfj, imageURL: "", createdDate: 0)
     static var passedMyData: [[String: Any]] = []
     static var passedUserData: [[String: Any]] = []
     static var cardCounting: Int = 0
@@ -90,6 +91,42 @@ final class HomeUserCardViewModel {
         }
     }
     
+    func updateMatcingData(_ userId: String) {
+            docRef.document(userId).updateData(
+                [
+                    sendedlikesUpdateFiled: FieldValue.arrayRemove([partnerSendedLikeData.asDictionary()])
+                ]) { error in
+                    if let error = error {
+                        print("삭제 my 에러: \(error)")
+                    }
+                }
+        
+        DispatchQueue.global().async { [self] in
+            docRef.document(currentUser.userId).getDocument { [self] (document, error) in
+                if let error = error {
+                    print("에러 : \(error)")
+                } else if let document = document, document.exists {
+                    if let data = try? document.data(as: Like.self), var recivedlikes = data.recivedlikes {
+                        recivedlikes.removeAll { $0.likedUserId == userId }
+                        let recivedlikesDictArray = recivedlikes.map { $0.asDictionary() }
+                        docRef.document(currentUser.userId).updateData(
+                            [
+                                "recivedlikes": recivedlikesDictArray
+                            ]) { error in
+                                if let error = error {
+                                    print("에러 : \(error)")
+                                } else {
+                                    print("매칭 문서 업데이트 오류")
+                                }
+                            }
+                    }
+                } else {
+                    print("해당 문서가 존재하지 않습니다.")
+                }
+            }
+        }
+    }
+    
     func purchaseChu(currentChu: Int, purchaseChu: Int) {
         FirestoreService.shared.updateDocument(collectionId: .users, documentId: currentUser.userId, field: "chuCount", data: currentChu - purchaseChu, completion: { _ in
             UserDefaultsManager.shared.updateChuCount(currentChu - purchaseChu)
@@ -99,4 +136,31 @@ final class HomeUserCardViewModel {
             }
         })
     }
+    
+    func checkYouLikeMe(_ partnerId: String, _ myId: String, completion: @escaping (Bool) -> Void) {
+        var result = false
+        let dbRef = Firestore.firestore().collection("likes")
+        
+        DispatchQueue.global().async {
+            dbRef.document(partnerId).getDocument { [self] (document, error) in
+                if let error = error {
+                    print("Error getting document: \(error)")
+                    completion(false)
+                } else if let document = document, document.exists {
+                    if let data = try? document.data(as: Like.self), let sendedLikes = data.sendedlikes {
+                        var sendedLikesData: [Like.LikeInfo] = sendedLikes
+                        for data in sendedLikesData where data.likedUserId == myId {
+                            partnerSendedLikeData = data
+                            result = true
+                        }
+                    }
+                    completion(result)
+                } else {
+                    print("해당 문서가 존재하지 않습니다.")
+                    completion(false)
+                }
+            }
+        }
+    }
+    
 }

--- a/Pico/Home/ViewModel/HomeViewModel.swift
+++ b/Pico/Home/ViewModel/HomeViewModel.swift
@@ -18,12 +18,18 @@ final class HomeViewModel {
     var blocks = BehaviorRelay<[Block.BlockInfo]>(value: [])
     static var filterGender: [GenderType] = GenderType.allCases
     static var filterMbti: [MBTIType] = MBTIType.allCases
-    static var filterAgeMin: Int = 24
-    static var filterAgeMax: Int = 34
+    static var filterAgeMin: Int = calculateAge(type: "min")
+    static var filterAgeMax: Int = calculateAge(type: "max")
     static var filterDistance: Int = 501
     private let loginUser = UserDefaultsManager.shared.getUserData()
     private let disposeBag = DisposeBag()
-    
+    private var age: Int {
+        let calendar = Calendar.current
+        let currentDate = Date()
+        let birthdate = UserDefaultsManager.shared.getUserData().birth.toDate()
+        let ageComponents = calendar.dateComponents([.year], from: birthdate, to: currentDate)
+        return ageComponents.year ?? 0
+    }
     init() {
         loadFilterDefault()
         loadMySendBlocks()
@@ -31,6 +37,23 @@ final class HomeViewModel {
         loadUsersCodable()
     }
     
+    private static func calculateAge(type: String?) -> Int {
+        let calendar = Calendar.current
+        let currentDate = Date()
+        let birthdate = UserDefaultsManager.shared.getUserData().birth.toDate()
+        let ageComponents = calendar.dateComponents([.year], from: birthdate, to: currentDate)
+        var age: Int
+        if type == "min" {
+            age = Int(ageComponents.year ?? 24) - 5
+            if age >= 60 { age = 59 }
+            age = max(age, 19)
+        } else {
+            age = Int(ageComponents.year ?? 34) + 5
+            age = min(age, 60)
+        }
+        return age
+    }
+
     func calculateDistance(user: User) -> CLLocationDistance {
         let currentUserLoc = CLLocation(latitude: loginUser.latitude, longitude: loginUser.longitude)
         let otherUserLoc = CLLocation(latitude: user.location.latitude, longitude: user.location.longitude)
@@ -72,7 +95,7 @@ final class HomeViewModel {
                     var users = [User]()
                     for document in querySnapshot!.documents {
                         if let userdata = try? document.data(as: User.self) {
-                            if userdata.id != self.loginUser.userId {
+                            if userdata.id != self.loginUser.userId && userdata.id.prefix(4) != "test" {
                                 users.append(userdata)
                             }
                         } else {

--- a/Pico/Home/ViewModel/HomeViewModel.swift
+++ b/Pico/Home/ViewModel/HomeViewModel.swift
@@ -23,13 +23,6 @@ final class HomeViewModel {
     static var filterDistance: Int = 501
     private let loginUser = UserDefaultsManager.shared.getUserData()
     private let disposeBag = DisposeBag()
-    private var age: Int {
-        let calendar = Calendar.current
-        let currentDate = Date()
-        let birthdate = UserDefaultsManager.shared.getUserData().birth.toDate()
-        let ageComponents = calendar.dateComponents([.year], from: birthdate, to: currentDate)
-        return ageComponents.year ?? 0
-    }
     init() {
         loadFilterDefault()
         loadMySendBlocks()


### PR DESCRIPTION
새친구 새로고침 하고 안나오게 하는건 rx로 받아오면서 필터에 걸러질때 0명이였다가 서버 다 불러와지면 생기고 해서
연동 문제가 좀 있어서 일단 사용자가 알아보기 쉽게 문구 변경하고 새로고침 버튼 밑에 필터 이동하는 버튼 임시추가로 해두었습니다.
![simulator_screenshot_78937394-9039-4685-A9DC-234E029710B7](https://github.com/APP-iOS2/final-pico/assets/115560272/182a7a28-9595-48f8-a32a-2a92ff92ebb0)

test 아이디 문서 id가 test로 시작하는 모든 유저는 안나오게 해놨습니다

홈에서 나를 좋아요 누른 사람을 내가 좋아요 눌렀을때 매칭알람이 양쪽으로 가게 되고
나를좋아요한 목록과 내가 좋아요한 목록에서 좋아요 문서를 둘다 삭제하고 매칭상태로 바꿈