### PR TITLE
매칭시스템 수정

### DIFF
--- a/Pico/Home/HomeUserCardViewController.swift
+++ b/Pico/Home/HomeUserCardViewController.swift
@@ -355,12 +355,16 @@ final class HomeUserCardViewController: UIViewController {
                 
                 if currentUser.userId.prefix(4) != "test" {
                     viewModel.checkYouLikeMe(user.id, currentUser.userId) { [self] result in
-                        if result {
-                            viewModel.saveLikeData(receiveUserInfo: user, likeType: .matching)
-                            viewModel.updateMatcingData(user.id)
-                            notificationServiceForPartner(.matching, .matching)
-                            notificationServiceForMe(.matching, .matching)
-                            homeViewController?.removedView.removeLast()
+                        if let likeInfo = result {
+                            if !likeInfo.isMatch {
+                                viewModel.saveLikeData(receiveUserInfo: user, likeType: .matching)
+                                viewModel.updateMatcingData(user.id)
+                                notificationServiceForPartner(.matching, .matching)
+                                notificationServiceForMe(.matching, .matching)
+                                homeViewController?.removedView.removeLast()
+                            } else {
+                                print("이미 매칭되었습니다.")
+                            }
                         } else {
                             viewModel.saveLikeData(receiveUserInfo: user, likeType: .like)
                             notificationServiceForPartner(.like, .like)
@@ -408,12 +412,16 @@ final class HomeUserCardViewController: UIViewController {
         }
         if currentUser.userId.prefix(4) != "test" {
             viewModel.checkYouLikeMe(user.id, currentUser.userId) { [self] result in
-                if result {
-                    viewModel.saveLikeData(receiveUserInfo: user, likeType: .matching)
-                    viewModel.updateMatcingData(user.id)
-                    notificationServiceForPartner(.matching, .matching)
-                    notificationServiceForMe(.matching, .matching)
-                    homeViewController?.removedView.removeLast()
+                if let likeInfo = result {
+                    if !likeInfo.isMatch {
+                        viewModel.saveLikeData(receiveUserInfo: user, likeType: .matching)
+                        viewModel.updateMatcingData(user.id)
+                        notificationServiceForPartner(.matching, .matching)
+                        notificationServiceForMe(.matching, .matching)
+                        homeViewController?.removedView.removeLast()
+                    } else {
+                        print("이미 매칭 되었습니다.")
+                    }
                 } else {
                     viewModel.saveLikeData(receiveUserInfo: user, likeType: .like)
                     notificationServiceForPartner(.like, .like)

--- a/Pico/Home/ViewModel/HomeUserCardViewModel.swift
+++ b/Pico/Home/ViewModel/HomeUserCardViewModel.swift
@@ -28,7 +28,7 @@ final class HomeUserCardViewModel {
                                                       mbti: receiveUserInfo.mbti,
                                                       imageURL: receiveUserInfo.imageURLs[0],
                                                       createdDate: Date().timeIntervalSince1970)
-            
+        
         let myLikeUserDic = myLikeUser.asDictionary()
         let myInfo: Like.LikeInfo = Like.LikeInfo(likedUserId: currentUser.userId,
                                                   likeType: likeType,
@@ -50,15 +50,27 @@ final class HomeUserCardViewModel {
                     print("평가 업데이트 에러: \(error)")
                 }
             }
-        docRef.document(receiveUserInfo.id).setData(
-            [
-                "userId": receiveUserInfo.id,
-                recivedlikesUpdateFiled: FieldValue.arrayUnion([myInfoDic])
-            ], merge: true) { error in
-                if let error = error {
-                    print("평가 업데이트 에러: \(error)")
+        if likeType == .matching {
+            docRef.document(receiveUserInfo.id).setData(
+                [
+                    "userId": receiveUserInfo.id,
+                    sendedlikesUpdateFiled: FieldValue.arrayUnion([myInfoDic])
+                ], merge: true) { error in
+                    if let error = error {
+                        print("평가 업데이트 에러: \(error)")
+                    }
                 }
-            }
+        } else {
+            docRef.document(receiveUserInfo.id).setData(
+                [
+                    "userId": receiveUserInfo.id,
+                    recivedlikesUpdateFiled: FieldValue.arrayUnion([myInfoDic])
+                ], merge: true) { error in
+                    if let error = error {
+                        print("평가 업데이트 에러: \(error)")
+                    }
+                }
+        }
     }
     
     func deleteLikeData() {
@@ -92,14 +104,14 @@ final class HomeUserCardViewModel {
     }
     
     func updateMatcingData(_ userId: String) {
-            docRef.document(userId).updateData(
-                [
-                    sendedlikesUpdateFiled: FieldValue.arrayRemove([partnerSendedLikeData.asDictionary()])
-                ]) { error in
-                    if let error = error {
-                        print("삭제 my 에러: \(error)")
-                    }
+        docRef.document(userId).updateData(
+            [
+                sendedlikesUpdateFiled: FieldValue.arrayRemove([partnerSendedLikeData.asDictionary()])
+            ]) { error in
+                if let error = error {
+                    print("삭제 my 에러: \(error)")
                 }
+            }
         
         DispatchQueue.global().async { [self] in
             docRef.document(currentUser.userId).getDocument { [self] (document, error) in
@@ -137,27 +149,27 @@ final class HomeUserCardViewModel {
         })
     }
     
-    func checkYouLikeMe(_ partnerId: String, _ myId: String, completion: @escaping (Bool) -> Void) {
-        var result = false
+    func checkYouLikeMe(_ partnerId: String, _ myId: String, completion: @escaping (Like.LikeInfo?) -> Void) {
+        var result: Like.LikeInfo?
         let dbRef = Firestore.firestore().collection("likes")
         
         DispatchQueue.global().async {
             dbRef.document(partnerId).getDocument { [self] (document, error) in
                 if let error = error {
                     print("Error getting document: \(error)")
-                    completion(false)
+                    completion(nil)
                 } else if let document = document, document.exists {
                     if let data = try? document.data(as: Like.self), let sendedLikes = data.sendedlikes {
                         var sendedLikesData: [Like.LikeInfo] = sendedLikes
                         for data in sendedLikesData where data.likedUserId == myId {
                             partnerSendedLikeData = data
-                            result = true
+                            result = partnerSendedLikeData
                         }
                     }
                     completion(result)
                 } else {
                     print("해당 문서가 존재하지 않습니다.")
-                    completion(false)
+                    completion(nil)
                 }
             }
         }

--- a/Pico/Like/LikeUViewController.swift
+++ b/Pico/Like/LikeUViewController.swift
@@ -24,6 +24,7 @@ final class LikeUViewController: UIViewController {
     private var isLoading = false
     private var isRefresh = false
     private var cellTapped: Bool = false
+    private var isMatching: Bool = false
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
@@ -39,6 +40,11 @@ final class LikeUViewController: UIViewController {
         configCollectionView()
         configRefresh()
         listLoadPublisher.onNext(())
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
     }
     
     private func configCollectionView() {

--- a/Pico/Like/ViewModel/LikeMeViewModel.swift
+++ b/Pico/Like/ViewModel/LikeMeViewModel.swift
@@ -121,7 +121,7 @@ final class LikeMeViewModel: ViewModelType {
                 }
                 
                 if let document = document, document.exists {
-                    if let datas = try? document.data(as: Like.self).recivedlikes?.filter({ $0.likeType != .dislike }) {
+                    if let datas = try? document.data(as: Like.self).recivedlikes?.filter({ $0.likeType == .like }) {
                         let sorted = datas.sorted {
                             return $0.createdDate > $1.createdDate
                         }
@@ -213,15 +213,16 @@ final class LikeMeViewModel: ViewModelType {
         guard let likeData: Like.LikeInfo = likeMeList[safe: index] else { return }
         likeMeList.remove(at: index)
         reloadTableViewPublisher.onNext(())
-        
-        let updateData: Like.LikeInfo = Like.LikeInfo(likedUserId: likeData.likedUserId, likeType: .matching, birth: likeData.birth, nickName: likeData.nickName, mbti: likeData.mbti, imageURL: likeData.imageURL, createdDate: Date().timeIntervalSince1970)
-        
         dbRef.collection(Collections.likes.name).document(currentUser.userId).updateData([
             "recivedlikes": FieldValue.arrayRemove([likeData.asDictionary()])
-        ])
-        dbRef.collection(Collections.likes.name).document(currentUser.userId).updateData([
-            "recivedlikes": FieldValue.arrayUnion([updateData.asDictionary()])
-        ])
+        ]) { error in
+            if let error = error {
+                print("매칭 업데이트 실패(라이크 데이터 삭제 실패): \(error)")
+            }
+        }
+
+        let updateData: Like.LikeInfo = Like.LikeInfo(likedUserId: likeData.likedUserId, likeType: .matching, birth: likeData.birth, nickName: likeData.nickName, mbti: likeData.mbti, imageURL: likeData.imageURL, createdDate: Date().timeIntervalSince1970)
+        
         dbRef.collection(Collections.likes.name).document(currentUser.userId).updateData([
             "sendedlikes": FieldValue.arrayUnion([updateData.asDictionary()])
         ])
@@ -236,11 +237,11 @@ final class LikeMeViewModel: ViewModelType {
                 guard let tempLike = tempLike else {
                     return
                 }
-                let sendedlikes = tempLike.sendedlikes
-                if let sendIndex = sendedlikes?.firstIndex(where: {
+                guard let sendedlikes = tempLike.sendedlikes else { return }
+                if let sendIndex = sendedlikes.firstIndex(where: {
                     $0.likedUserId == self.currentUser.userId
                 }) {
-                    guard let tempSendLike = sendedlikes?[safe: sendIndex] else { return }
+                    guard let tempSendLike = sendedlikes[safe: sendIndex] else { return }
                     updateSendLike = Like.LikeInfo(likedUserId: tempSendLike.likedUserId, likeType: .matching, birth: tempSendLike.birth, nickName: tempSendLike.nickName, mbti: tempSendLike.mbti, imageURL: tempSendLike.imageURL, createdDate: Date().timeIntervalSince1970)
                     dbRef.collection(Collections.likes.name).document(likeData.likedUserId).updateData([
                         "sendedlikes": FieldValue.arrayRemove([tempSendLike.asDictionary()])
@@ -253,9 +254,6 @@ final class LikeMeViewModel: ViewModelType {
                 dbRef.collection(Collections.likes.name).document(likeData.likedUserId).updateData([
                     "sendedlikes": FieldValue.arrayUnion([updateSendLike.asDictionary()])
                 ])
-                dbRef.collection(Collections.likes.name).document(likeData.likedUserId).updateData([
-                    "recivedlikes": FieldValue.arrayUnion([updateSendLike.asDictionary()])
-                ])
                 
                 let myNoti = Noti(receiveId: currentUser.userId, sendId: likeData.likedUserId, name: likeData.nickName, birth: likeData.birth, imageUrl: likeData.imageURL, notiType: .matching, mbti: likeData.mbti, createDate: Date().timeIntervalSince1970)
                 
@@ -263,6 +261,7 @@ final class LikeMeViewModel: ViewModelType {
                 let yourNoti = Noti(receiveId: likeData.likedUserId, sendId: currentUser.userId, name: currentUser.nickName, birth: currentUser.birth, imageUrl: currentUser.imageURL, notiType: .matching, mbti: yourMbti, createDate: Date().timeIntervalSince1970)
                 FirestoreService.shared.saveDocument(collectionId: .notifications, data: myNoti)
                 FirestoreService.shared.saveDocument(collectionId: .notifications, data: yourNoti)
+                
                 let mailModel = MailSendViewModel()
                 let receiverUser = User(id: likeData.likedUserId, mbti: likeData.mbti, phoneNumber: "", gender: .etc, birth: likeData.birth, nickName: likeData.nickName, location: Location(address: "서울시 강남구", latitude: 10, longitude: 10), imageURLs: [likeData.imageURL], createdDate: 10, subInfo: nil, reports: nil, blocks: nil, chuCount: 0, isSubscribe: false)
                 mailModel.saveMailData(receiveUser: receiverUser, message: "서로 매칭되었습니다.", type: .matching)

--- a/Pico/Like/ViewModel/LikeUViewModel.swift
+++ b/Pico/Like/ViewModel/LikeUViewModel.swift
@@ -35,7 +35,7 @@ final class LikeUViewModel: ViewModelType {
             }
         }
     }
-
+    
     private var isEmptyPublisher = PublishSubject<Bool>()
     private let reloadCollectionViewPublisher = PublishSubject<Void>()
     private let disposeBag = DisposeBag()
@@ -43,7 +43,7 @@ final class LikeUViewModel: ViewModelType {
     private var currentChuCount = UserDefaultsManager.shared.getChuCount()
     private let pageSize = 10
     var startIndex = 0
-
+    
     func transform(input: Input) -> Output {
         input.refresh
             .withUnretained(self)
@@ -96,10 +96,10 @@ final class LikeUViewModel: ViewModelType {
             .map { viewModel, _ in
                 UserDefaultsManager.shared.updateChuCount(viewModel.currentChuCount)
             }
-            
+        
         return Output(likeUIsEmpty: isEmpty, reloadCollectionView: reloadCollectionViewPublisher.asObservable(), resultMessage: resultMessage)
     }
-
+    
     private func loadNextPage() {
         let dbRef = Firestore.firestore()
         let ref = dbRef.collection(Collections.likes.name).document(currentUser.userId)
@@ -116,7 +116,11 @@ final class LikeUViewModel: ViewModelType {
                 if let document = document, document.exists {
                     if let datas = try? document.data(as: Like.self).sendedlikes?.filter({ $0.likeType != .dislike }) {
                         let sorted = datas.sorted {
-                            return $0.createdDate > $1.createdDate
+                            if $0.isMatch != $1.isMatch {
+                                return !$0.isMatch
+                            } else {
+                                return $0.createdDate > $1.createdDate
+                            }
                         }
                         if startIndex > sorted.count - 1 {
                             return


### PR DESCRIPTION
전체적인 매칭 시스템 오류 수정
- 매칭 시 I Like U 뷰에서 (상대방, 나 둘 다) 확인 가능
- I Like U 뷰에서 매칭 데이터가 더 밑으로 가도록 정렬 변경 (기본적으론 날짜순 정렬에 매칭 데이터 하단 배치)
- 이미 매칭 된 데이터가 홈 카드에 떠서 좋아요를 넘길 시 데이터가 중복 추가 안되도록 수정